### PR TITLE
Reorder dashboard sections to show tasks first

### DIFF
--- a/components/DashboardClient.tsx
+++ b/components/DashboardClient.tsx
@@ -73,11 +73,6 @@ const DashboardClient: React.FC<DashboardClientProps> = ({ userId, userTimezone 
 
   return (
     <div className="space-y-12">
-      {/* Routines Section */}
-      <section>
-        <RoutineList ref={routineListRef} onRoutineSkipped={handleRoutineSkipped} />
-      </section>
-
       {/* Tasks Section */}
       <section>
         {loading ? (
@@ -92,6 +87,11 @@ const DashboardClient: React.FC<DashboardClientProps> = ({ userId, userTimezone 
             <DashboardTaskList ref={taskListRef} userId={userId} onTaskUpdate={handleTaskUpdate} />
           </>
         )}
+      </section>
+
+      {/* Routines Section */}
+      <section>
+        <RoutineList ref={routineListRef} onRoutineSkipped={handleRoutineSkipped} />
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
- Display today's tasks above the routines list on the dashboard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c0621c9bd88326b4e39e9d9ff5bbc4