### PR TITLE
Add settings page with user preferences

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,38 @@
+import { auth, currentUser } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import SettingsForm from "@/components/SettingsForm";
+import { getCurrentUser } from "@/lib/queries/getCurrentUser";
+
+export default async function SettingsPage() {
+  const { userId } = await auth();
+  const user = await currentUser();
+
+  if (!userId) {
+    redirect("/sign-in");
+  }
+
+  const dbUser = await getCurrentUser(userId);
+
+  const serializedUser = user
+    ? {
+        id: user.id,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        imageUrl: user.imageUrl,
+        username: user.username,
+        emailAddress: user.emailAddresses?.[0]?.emailAddress,
+      }
+    : null;
+
+  return (
+    <div className="min-h-screen flex flex-col bg-default-50">
+      <Navbar user={serializedUser} />
+      <main className="flex-1 flex justify-center items-center p-6">
+        {dbUser && <SettingsForm user={dbUser} />}
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -229,30 +229,37 @@ export default function Navbar({ user }: NavbarProps) {
                     >
                       Profile
                     </DropdownItem>
-                    <DropdownItem
-                      key="files"
-                      description="Manage your files"
-                      onClick={() => router.push("/dashboard")}
-                    >
-                      My Routines
-                    </DropdownItem>
-                    <DropdownItem
-                      key="change-password"
-                      description="Update your account password"
-                      onClick={() => router.push("/change-password")}
-                    >
-                      Change Password
-                    </DropdownItem>
-                    <DropdownItem
-                      key="logout"
-                      description="Sign out of your account"
-                      className="text-danger"
-                      color="danger"
-                      onClick={handleSignOut}
-                    >
-                      Sign Out
-                    </DropdownItem>
-                  </DropdownMenu>
+                      <DropdownItem
+                        key="routines"
+                        description="View your routines"
+                        onClick={() => router.push("/dashboard")}
+                      >
+                        My Routines
+                      </DropdownItem>
+                      <DropdownItem
+                        key="settings"
+                        description="Update your preferences"
+                        onClick={() => router.push("/settings")}
+                      >
+                        Settings
+                      </DropdownItem>
+                      <DropdownItem
+                        key="change-password"
+                        description="Update your account password"
+                        onClick={() => router.push("/change-password")}
+                      >
+                        Change Password
+                      </DropdownItem>
+                      <DropdownItem
+                        key="logout"
+                        description="Sign out of your account"
+                        className="text-danger"
+                        color="danger"
+                        onClick={handleSignOut}
+                      >
+                        Sign Out
+                      </DropdownItem>
+                    </DropdownMenu>
                 </Dropdown>
               </div>
             </SignedIn>
@@ -383,6 +390,13 @@ export default function Navbar({ user }: NavbarProps) {
                     onClick={() => setIsMobileMenuOpen(false)}
                   >
                     Profile
+                  </Link>
+                  <Link
+                    href="/settings"
+                    className="py-2 px-3 hover:bg-default-100 rounded-md transition-colors"
+                    onClick={() => setIsMobileMenuOpen(false)}
+                  >
+                    Settings
                   </Link>
                   <button
                     className="py-2 px-3 text-left text-danger hover:bg-danger-50 rounded-md transition-colors mt-4"

--- a/components/SettingsForm.tsx
+++ b/components/SettingsForm.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Button } from "@heroui/button";
+import { Input } from "@heroui/input";
+import { Select, SelectItem } from "@heroui/select";
+import { Card, CardBody, CardHeader } from "@heroui/card";
+import { Divider } from "@heroui/divider";
+import { AlertCircle, User, MessageCircle, Target } from "lucide-react";
+import { TimezoneSelect } from "@/components/TimezoneSelect";
+import { settingsSchema, type SettingsFormData } from "@/schemas/settingsSchema";
+import { PRODUCTIVITY_GOALS } from "@/schemas/onboardingSchema";
+
+const COMMON_LANGUAGES = [
+  "English",
+  "Spanish",
+  "French",
+  "German",
+  "Italian",
+  "Portuguese",
+  "Chinese",
+  "Japanese",
+  "Korean",
+  "Arabic",
+  "Russian",
+  "Hindi",
+];
+
+type Props = {
+  user: {
+    fullName: string | null;
+    timezone: string;
+    language: string;
+    profilePictureUrl?: string | null;
+    productivityGoal?: string | null;
+  };
+};
+
+export default function SettingsForm({ user }: Props) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors },
+  } = useForm<SettingsFormData>({
+    resolver: zodResolver(settingsSchema),
+    defaultValues: {
+      fullName: user.fullName || "",
+      timezone: user.timezone || "",
+      language: user.language || "English",
+      profilePictureUrl: user.profilePictureUrl || "",
+      productivityGoal: (user.productivityGoal as SettingsFormData["productivityGoal"]) || undefined,
+    },
+  });
+
+  const languageValue = watch("language");
+  const productivityGoalValue = watch("productivityGoal");
+
+  const onSubmit = async (data: SettingsFormData) => {
+    setIsSubmitting(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      const response = await fetch("/api/users/me", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(data),
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to update settings");
+      }
+
+      setSuccess(true);
+    } catch (err) {
+      console.error("Error updating settings:", err);
+      setError("Failed to update settings. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Card className="w-full max-w-xl border border-default-200 bg-default-50 shadow-xl">
+      <CardHeader className="flex flex-col gap-1 items-center pb-2">
+        <h1 className="text-2xl font-bold text-default-900">Settings</h1>
+      </CardHeader>
+
+      <Divider />
+
+      <CardBody className="py-6">
+        {error && (
+          <div className="bg-danger-50 text-danger-700 p-4 rounded-lg mb-6 flex items-center gap-2">
+            <AlertCircle className="h-5 w-5 flex-shrink-0" />
+            <p>{error}</p>
+          </div>
+        )}
+
+        {success && (
+          <div className="bg-success-50 text-success-700 p-4 rounded-lg mb-6">
+            Settings updated successfully.
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+          <div className="space-y-2">
+            <label htmlFor="fullName" className="text-sm font-medium text-default-900">
+              Full Name
+            </label>
+            <Input
+              id="fullName"
+              placeholder="Enter your full name"
+              startContent={<User className="h-4 w-4 text-default-500" />}
+              isInvalid={!!errors.fullName}
+              errorMessage={errors.fullName?.message}
+              {...register("fullName")}
+              className="w-full"
+            />
+          </div>
+
+          <TimezoneSelect
+            value={watch("timezone")}
+            onChange={(value) => setValue("timezone", value)}
+            isInvalid={!!errors.timezone}
+            errorMessage={errors.timezone?.message}
+          />
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-default-900">
+              Preferred Language
+            </label>
+            <Select
+              placeholder="Select your language"
+              selectedKeys={languageValue ? [languageValue] : []}
+              onSelectionChange={(keys) => {
+                const selected = [...keys][0] as string;
+                setValue("language", selected);
+              }}
+              isInvalid={!!errors.language}
+              errorMessage={errors.language?.message}
+              startContent={<MessageCircle className="h-4 w-4 text-default-500" />}
+              className="w-full"
+            >
+              {COMMON_LANGUAGES.map((lang) => (
+                <SelectItem key={lang}>{lang}</SelectItem>
+              ))}
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-default-900">
+              What's your main productivity goal?
+            </label>
+            <Select
+              placeholder="Select your primary goal"
+              selectedKeys={productivityGoalValue ? [productivityGoalValue] : []}
+              onSelectionChange={(keys) => {
+                const selected = [...keys][0] as typeof PRODUCTIVITY_GOALS[number];
+                setValue("productivityGoal", selected);
+              }}
+              isInvalid={!!errors.productivityGoal}
+              errorMessage={errors.productivityGoal?.message}
+              startContent={<Target className="h-4 w-4 text-default-500" />}
+              className="w-full"
+              description="Optional: Help us personalize your experience"
+            >
+              {PRODUCTIVITY_GOALS.map((goal) => (
+                <SelectItem key={goal}>{goal}</SelectItem>
+              ))}
+            </Select>
+          </div>
+
+          <Button
+            type="submit"
+            color="primary"
+            className="w-full"
+            isLoading={isSubmitting}
+          >
+            {isSubmitting ? "Saving..." : "Save Settings"}
+          </Button>
+        </form>
+      </CardBody>
+    </Card>
+  );
+}

--- a/components/TimezoneSelect.tsx
+++ b/components/TimezoneSelect.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Select, SelectItem } from "@heroui/select";
 import { Globe } from "lucide-react";
+import { DateTime } from "luxon";
 
-const TIMEZONE_OPTIONS = [
+const FALLBACK_TIMEZONE_OPTIONS = [
   { label: "(GMT -08:00) Pacific Time (US & Canada)", value: "America/Los_Angeles" },
   { label: "(GMT -07:00) Mountain Time (US & Canada)", value: "America/Denver" },
   { label: "(GMT -06:00) Central Time (US & Canada)", value: "America/Chicago" },
@@ -16,7 +17,6 @@ const TIMEZONE_OPTIONS = [
   { label: "(GMT +09:00) Japan Standard Time", value: "Asia/Tokyo" },
   { label: "(GMT +10:00) Australian Eastern Time", value: "Australia/Sydney" },
   { label: "(GMT +13:00) New Zealand Daylight Time", value: "Pacific/Auckland" },
-  // Additional 10 timezone options
   { label: "(GMT -03:00) Brazil (São Paulo)", value: "America/Sao_Paulo" },
   { label: "(GMT -05:00) Colombia (Bogotá)", value: "America/Bogota" },
   { label: "(GMT +02:00) South Africa (Cape Town)", value: "Africa/Johannesburg" },
@@ -38,6 +38,18 @@ type Props = {
 
 export function TimezoneSelect({ value, onChange, isInvalid, errorMessage }: Props) {
   const [autoDetected, setAutoDetected] = useState<string>("");
+  const timezoneOptions = useMemo(() => {
+    if (typeof Intl.supportedValuesOf === "function") {
+      return Intl.supportedValuesOf("timeZone").map((tz) => {
+        const offset = DateTime.now().setZone(tz).toFormat("ZZ");
+        return {
+          value: tz,
+          label: `(GMT${offset}) ${tz.replace(/_/g, " ")}`,
+        };
+      });
+    }
+    return FALLBACK_TIMEZONE_OPTIONS;
+  }, []);
 
   useEffect(() => {
     try {
@@ -72,10 +84,8 @@ export function TimezoneSelect({ value, onChange, isInvalid, errorMessage }: Pro
         className="w-full"
         description={autoDetected ? `Auto-detected: ${autoDetected}` : undefined}
       >
-        {TIMEZONE_OPTIONS.map((tz) => (
-          <SelectItem key={tz.value}>
-            {tz.label}
-          </SelectItem>
+        {timezoneOptions.map((tz) => (
+          <SelectItem key={tz.value}>{tz.label}</SelectItem>
         ))}
       </Select>
     </div>

--- a/schemas/settingsSchema.ts
+++ b/schemas/settingsSchema.ts
@@ -1,0 +1,19 @@
+import * as z from "zod";
+import { PRODUCTIVITY_GOALS } from "./onboardingSchema";
+
+export const settingsSchema = z.object({
+  fullName: z
+    .string()
+    .min(1, { message: "Full name is required" })
+    .max(100, { message: "Full name must be less than 100 characters" }),
+  timezone: z.string().min(1, { message: "Timezone is required" }),
+  language: z.string().min(1, { message: "Language is required" }),
+  profilePictureUrl: z
+    .string()
+    .url({ message: "Please enter a valid URL" })
+    .optional()
+    .or(z.literal("")),
+  productivityGoal: z.enum(PRODUCTIVITY_GOALS).optional(),
+});
+
+export type SettingsFormData = z.infer<typeof settingsSchema>;


### PR DESCRIPTION
## Summary
- add settings page and form to update user profile info
- wire up settings navigation links in navbar
- expand timezone selector to cover the full set of IANA time zones
- refine navigation wording to center on routines

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: requires interactive ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68c6d00714b48326b3d5a18a99dd811a