### PR TITLE
Respect user's timezone in upcoming task countdown

### DIFF
--- a/components/CountdownTimer.tsx
+++ b/components/CountdownTimer.tsx
@@ -1,100 +1,53 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { DateTime } from "luxon";
 
 interface CountdownTimerProps {
   userTimezone?: string;
 }
 
-const CountdownTimer: React.FC<CountdownTimerProps> = ({ userTimezone = 'UTC' }) => {
-  const [timeLeft, setTimeLeft] = useState<string>("");
-  const [nextDrop, setNextDrop] = useState<string>("");
+const CountdownTimer: React.FC<CountdownTimerProps> = ({ userTimezone = "UTC" }) => {
+  const [timeLeft, setTimeLeft] = useState("--:--:--");
+  const [nextDrop, setNextDrop] = useState("5:00 AM");
 
   useEffect(() => {
     const updateCountdown = () => {
       try {
-        const now = new Date();
-        const userNow = new Intl.DateTimeFormat('en-US', {
-          timeZone: userTimezone,
-          year: 'numeric',
-          month: '2-digit',
-          day: '2-digit',
-          hour: '2-digit',
-          minute: '2-digit',
-          second: '2-digit',
-          hour12: false
-        }).formatToParts(now);
+        const now = DateTime.now().setZone(userTimezone);
 
-        // Parse the current time in user's timezone
-        const year = parseInt(userNow.find(part => part.type === 'year')?.value || '0');
-        const month = parseInt(userNow.find(part => part.type === 'month')?.value || '0');
-        const day = parseInt(userNow.find(part => part.type === 'day')?.value || '0');
-        const hour = parseInt(userNow.find(part => part.type === 'hour')?.value || '0');
-        const minute = parseInt(userNow.find(part => part.type === 'minute')?.value || '0');
-        const second = parseInt(userNow.find(part => part.type === 'second')?.value || '0');
-
-        // Calculate next 5:00 AM in user's timezone
-        let nextFiveAM = new Date();
-        nextFiveAM.setFullYear(year, month - 1, day); // month is 0-indexed
-        nextFiveAM.setHours(5, 0, 0, 0);
-
-        // If it's already past 5:00 AM today, move to tomorrow
-        if (hour >= 5) {
-          nextFiveAM.setDate(nextFiveAM.getDate() + 1);
+        let nextFive = now.set({ hour: 5, minute: 0, second: 0, millisecond: 0 });
+        if (now >= nextFive) {
+          nextFive = nextFive.plus({ days: 1 });
         }
 
-        // Convert to user's timezone for display
-        const nextDropTime = new Intl.DateTimeFormat('en-US', {
-          timeZone: userTimezone,
-          hour: '2-digit',
-          minute: '2-digit',
-          hour12: true,
-          timeZoneName: 'short'
-        }).format(nextFiveAM);
+        setNextDrop(nextFive.toFormat("h:mm a z"));
 
-        setNextDrop(nextDropTime);
+        const diff = nextFive.diff(now, ["hours", "minutes", "seconds"]).toObject();
+        const hours = Math.floor(diff.hours ?? 0).toString().padStart(2, "0");
+        const minutes = Math.floor(diff.minutes ?? 0).toString().padStart(2, "0");
+        const seconds = Math.floor(diff.seconds ?? 0).toString().padStart(2, "0");
 
-        // Calculate time difference
-        const timeDiff = nextFiveAM.getTime() - now.getTime();
-        
-        if (timeDiff <= 0) {
-          setTimeLeft("00:00:00");
-          return;
-        }
-
-        const hours = Math.floor(timeDiff / (1000 * 60 * 60));
-        const minutes = Math.floor((timeDiff % (1000 * 60 * 60)) / (1000 * 60));
-        const seconds = Math.floor((timeDiff % (1000 * 60)) / 1000);
-
-        setTimeLeft(
-          `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`
-        );
+        setTimeLeft(`${hours}:${minutes}:${seconds}`);
       } catch (error) {
-        console.error('Error calculating countdown:', error);
+        console.error("Error calculating countdown:", error);
         setTimeLeft("--:--:--");
         setNextDrop("5:00 AM");
       }
     };
 
-    // Update immediately
     updateCountdown();
-
-    // Update every second
     const interval = setInterval(updateCountdown, 1000);
-
     return () => clearInterval(interval);
   }, [userTimezone]);
 
   return (
     <div className="text-center text-default-600 space-y-1">
-      <p className="text-sm">
-        Next drop at {nextDrop}
-      </p>
-      <p className="text-lg font-mono font-semibold text-primary-600">
-        {timeLeft}
-      </p>
+      <p className="text-sm">Next drop at {nextDrop}</p>
+      <p className="text-lg font-mono font-semibold text-primary-600">{timeLeft}</p>
     </div>
   );
 };
 
-export default CountdownTimer; 
+export default CountdownTimer;
+


### PR DESCRIPTION
## Summary
- compute next task drop and countdown using the user's timezone with Luxon

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(prompts for ESLint configuration, cannot run)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d5d18bbc8326b54eadc5273a5fba